### PR TITLE
Add Travis configuration file. Sets up a Go 1.8 project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: go
+go:
+- 1.8


### PR DESCRIPTION
This very simple Travis configuration will just run `go test -v ./...`

WDYT @calonso ?