### PR TITLE
Manage dependencies with Glide (http://glide.sh/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.swp
+
+# Vendoring
+vendor/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # couchdb-admin
 WIP CouchDB admin tooling
+
+---
+
+## Vendoring
+
+`couchdb-admin` currently uses [Glide](http://glide.sh/) for vendoring.

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,10 @@
+hash: c4247a252248e319eeb064c5bf66e1b8096bbcbc7c51a8f0bdb730e43e58a168
+updated: 2017-06-06T23:20:54.930276584+02:00
+imports:
+- name: github.com/kr/pretty
+  version: cfb55aafdaf3ec08f0db22699ab822c50091b1c4
+- name: github.com/kr/text
+  version: 7cafcd837844e784b526369c9bce262804aebc60
+- name: github.com/urfave/cli
+  version: d70f47eeca3afd795160003bc6e28b001d60c67c
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,4 @@
+package: github.com/cabify/couchdb-admin
+import:
+- package: github.com/kr/pretty
+- package: github.com/urfave/cli


### PR DESCRIPTION
Use Glide to manage the external dependencies. This should enable us to generate repeatable builds.