### PR TITLE
Add project Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,4 +353,13 @@ $ couchdb-admin describe_db --db=mydb
 
 `couchdb-admin` currently uses [Glide](http://glide.sh/) for vendoring.
 
+## Developing couchdb-admin
 
+If you wish to work on couchdb-admin you'll first need Go installed (version 1.8+ is required). Make sure you have Go properly installed, including setting up your GOPATH.
+
+Next, clone this repository into $GOPATH/src/github.com/cabify/couchdb-admin. Then enter into the directory `cli/couchdb-admin` and type:
+```
+$ make all
+```
+
+This will generate a binary file `couchdb-admin` which you can now play with. In case you are running on macOS type `make darwin` instead.

--- a/cli/couchdb-admin/Makefile
+++ b/cli/couchdb-admin/Makefile
@@ -1,0 +1,23 @@
+GOARCH = amd64
+PREFIX = "couchdb-admin"
+VERSION?=?
+COMMIT=$(shell git rev-parse HEAD)
+BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
+
+LDFLAGS = -ldflags "-X main.VERSION=${VERSION} -X main.COMMIT=${COMMIT} -X main.BRANCH=${BRANCH}"
+
+all: clean default
+
+default: 
+	GOOS=linux GOARCH=${GOARCH} go build ${LDFLAGS} -o ${PREFIX}
+
+linux: 
+	GOOS=linux GOARCH=${GOARCH} go build ${LDFLAGS} -o ${PREFIX}-linux-${GOARCH}
+
+darwin: 
+	GOOS=darwin GOARCH=${GOARCH} go build ${LDFLAGS} -o ${PREFIX}-darwin-${GOARCH}
+
+clean:
+	-rm -f ${PREFIX}*
+
+.PHONY: default linux darwin clean

--- a/cli/couchdb-admin/main.go
+++ b/cli/couchdb-admin/main.go
@@ -16,7 +16,7 @@ func main() {
 	app.Name = "CouchDB 2 Admin tool"
 	app.Usage = "Easily operate a CouchDB 2 cluster"
 	app.UsageText = "$ couchdb-admin [COMMAND] [OPTIONS]"
-	app.Version = "0.0.1"
+	app.Version = "0.1.0"
 	app.Authors = []cli.Author{cli.Author{Name: "Carlos Alonso", Email: "carlos.alonso@cabify.com"}}
 
 	app.Flags = []cli.Flag{


### PR DESCRIPTION
By running `make all` you'll get a binary file `couchdb-admin` that will run under linux and amd64 arch.

In case you want to quickly test the binary on macOS run `make darwin` which will create the file `couchdb-admin-darwin-amd64`.

```
./couchdb-admin-darwin-amd64
NAME:
   CouchDB 2 Admin tool - Easily operate a CouchDB 2 cluster

USAGE:
   $ couchdb-admin [COMMAND] [OPTIONS]

VERSION:
   0.1.0

AUTHOR:
   Carlos Alonso <carlos.alonso@cabify.com>

COMMANDS:
     describe_db               Get a db's shards placement info
     replicate                 Replicate a database's shard into a node not containing it already
     add_node                  Join a node into the cluster
     describe_cluster          Get information of the cluster's nodes
     create_db                 Create a new database
     remove_replica            Remove a shard from a particular node
     disable_maintenance_mode  Disable a node's maintenance mode
     set_config                Set a config value of a particular node
     remove_node               Remove a node from the cluster
     help, h                   Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --server value    The server to connect to (default: "127.0.0.1")
   --admin value     Admin of the DB (default: "admin")
   --password value  Password for the db's admin (default: "password")
   --help, -h        show help
   --version, -v     print the version
``` 